### PR TITLE
Prevent VOCR from crashing

### DIFF
--- a/VOCR/NSRunningApplication Extension.swift
+++ b/VOCR/NSRunningApplication Extension.swift
@@ -13,6 +13,9 @@ extension NSRunningApplication {
 		let appRef = AXUIElementCreateApplication(self.processIdentifier)
 		var windowList:CFTypeRef?
 		AXUIElementCopyAttributeValue(appRef, "AXWindows" as CFString, &windowList)
+        if windowList != nil {
 		return windowList as! [AXUIElement]
+        } else {
+            return []}
 	}
 }

--- a/VOCR/Take Screenshot.swift
+++ b/VOCR/Take Screenshot.swift
@@ -29,6 +29,9 @@ func TakeScreensShots() -> CGImage? {
 	let appID = currentApp!.processIdentifier
 	let appElement = AXUIElementCreateApplication(appID)
 	let windows = currentApp?.windows()
+    if (windows!.isEmpty) {
+        return nil
+    }
 	let window = windows![0]
 	print("Window information")
 	print(window.value(of: "AXTitle"))


### PR DESCRIPTION
VOCR will crash when attempting to run the scan on an empty window because the array of windows will not be unwrapped.
A simple "nil" check should prevent this from happening by returning an empty array if the app has no active window.