### PR TITLE
Make mouse movement a toggle option.

### DIFF
--- a/VOCR/Navigation.swift
+++ b/VOCR/Navigation.swift
@@ -111,7 +111,9 @@ class Navigation {
 		c = -1
 		correctLimit()
 		print("\(l), \(w)")
+        if Settings.moveMouse {
 		CGDisplayMoveCursorToPoint(0, convert2coordinates(displayResults[l][w].boundingBox))
+        }
 		Accessibility.speak(displayResults[l][w].topCandidates(1)[0].string)
 	}
 	
@@ -123,7 +125,9 @@ class Navigation {
 		c = -1
 		correctLimit()
 		print("\(l), \(w)")
+        if Settings.moveMouse {
 		CGDisplayMoveCursorToPoint(0, convert2coordinates(displayResults[l][w].boundingBox))
+        }
 		Accessibility.speak(displayResults[l][w].topCandidates(1)[0].string)
 	}
 
@@ -136,7 +140,9 @@ class Navigation {
 		c = -1
 		correctLimit()
 		print("\(l), \(w)")
+        if Settings.moveMouse {
 		CGDisplayMoveCursorToPoint(0, convert2coordinates(displayResults[l][w].boundingBox))
+        }
 		var line = ""
 		for r in displayResults[l] {
 			line += " \(r.topCandidates(1)[0].string)"
@@ -153,7 +159,9 @@ class Navigation {
 		c = -1
 		correctLimit()
 		print("\(l), \(w)")
+        if Settings.moveMouse {
 		CGDisplayMoveCursorToPoint(0, convert2coordinates(displayResults[l][w].boundingBox))
+        }
 		var line = ""
 		for r in displayResults[l] {
 			line += " \(r.topCandidates(1)[0].string)"

--- a/VOCR/Settings.swift
+++ b/VOCR/Settings.swift
@@ -12,7 +12,8 @@ struct Settings {
 	
 	static var positionReset = true
 	static var positionalAudio = false
-
+    static var moveMouse = false
+    
 	static func load() {
 		let defaults = UserDefaults.standard
 
@@ -21,6 +22,8 @@ struct Settings {
 		debugPrint("positionReset \(Settings.positionReset)")
 		Settings.positionalAudio = defaults.bool(forKey:"positionalAudio")
 		debugPrint("positionalAudio \(Settings.positionalAudio)")
+        Settings.moveMouse = defaults.bool(forKey: "moveMouse")
+        debugPrint("moveMouse \(Settings.moveMouse)")
 	}
 	
 	static func save() {

--- a/VOCR/VOCR Shortcuts.swift
+++ b/VOCR/VOCR Shortcuts.swift
@@ -15,7 +15,7 @@ struct Shortcuts {
 	let vo = HotKey(key:.v, modifiers:[.command,.shift, .control])
 	let resetPosition = HotKey(key:.r, modifiers:[.command,.shift, .control])
 	let positionalAudio = HotKey(key:.p, modifiers:[.command,.shift, .control])
-	
+    let moveMouse = HotKey(key:.m, modifiers:[.command, .shift, .control])
 	init() {
 		window.keyDownHandler = {
 			if !Accessibility.isTrusted(ask:true) {
@@ -53,8 +53,20 @@ struct Shortcuts {
 			}
 			Settings.save()
 		}
-		
-	}
+        moveMouse.keyDownHandler = {
+            if Settings.moveMouse {
+                Settings.moveMouse = false
+                Accessibility.speak("Disabled mouse movement")
+            } else {
+                Settings.moveMouse = true
+                Accessibility.speak("Enabled mouse movement.")
+            }
+            Settings.save()
+        }
+        
+            }
+        }
 	
-}
+	
+
 


### PR DESCRIPTION
As discussed in #15, this makes mouse movement to OCR results a toggle option. I thought I'd want a command to move the mouse to the current result, but that seems to be less necessary than I thought.