### PR TITLE
Automatically rescan the UI when the user performs a mouse click

### DIFF
--- a/VOCR/AppDelegate.swift
+++ b/VOCR/AppDelegate.swift
@@ -3,10 +3,47 @@ import AudioKit
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
+
+	private var eventMonitor: Any?
 	
 	let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
 	var windows:[NSWindow] = []
 	let shortcuts = Shortcuts()
+	
+	
+	func applicationWillFinishLaunching(_ notification: Notification) {
+		self.eventMonitor = NSEvent.addGlobalMonitorForEvents(
+			matching: [NSEvent.EventTypeMask.leftMouseDown],
+			handler: { (event: NSEvent) in
+				switch event.type {
+				case .leftMouseDown:
+					print("Left mouse click detected.")
+					if Navigation.shared.navigationShortcuts != nil {
+						Thread.sleep(forTimeInterval: 0.5)
+						initOCR()
+					}
+				case .rightMouseDown:
+					print("Right mouse click detected.")
+					if Navigation.shared.navigationShortcuts != nil {
+						Thread.sleep(forTimeInterval: 0.5)
+						initOCR()
+					}
+
+					
+				default:
+					break
+				}
+			  })
+			}
+
+func applicationWillTerminate(_ notification: Notification) {
+	if let eventMonitor = self.eventMonitor {
+		NSEvent.removeMonitor(eventMonitor)
+			}
+}
+
+
+	
 	
 	func applicationDidFinishLaunching(_ notification: Notification) {
 		let fileManager = FileManager.default

--- a/VOCR/Utils.swift
+++ b/VOCR/Utils.swift
@@ -124,6 +124,18 @@ func TakeScreensShots() -> CGImage? {
 	return CGDisplayCreateImage(activeDisplays[0], rect:CGRect(origin: Navigation.shared.cgPosition, size: Navigation.shared.cgSize))
 }
 
+func initOCR() {
+	if Navigation.shared.cgSize != CGSize() {
+		if let  cgImage = TakeScreensShots() {
+			Navigation.shared.startOCR(cgImage:cgImage)
+		} else {
+			Accessibility.speakWithSynthesizer("Faild to take a screenshot of \(Navigation.shared.appName), \(Navigation.shared.windowName)")
+		}
+	} else {
+		Accessibility.speakWithSynthesizer("Faild to access \(Navigation.shared.appName), \(Navigation.shared.windowName)")
+	}
+}
+
 func performOCR(cgImage:CGImage) -> [VNRecognizedTextObservation] {
 	let textRecognitionRequest = VNRecognizeTextRequest()
 	textRecognitionRequest.recognitionLevel = VNRequestTextRecognitionLevel.accurate

--- a/VOCR/VOCR Shortcuts.swift
+++ b/VOCR/VOCR Shortcuts.swift
@@ -24,15 +24,7 @@ struct Shortcuts {
 				return
 			}
 			setWindow(0)
-			if Navigation.shared.cgSize != CGSize() {
-				if let  cgImage = TakeScreensShots() {
-					Navigation.shared.startOCR(cgImage:cgImage)
-				} else {
-					Accessibility.speakWithSynthesizer("Faild to take a screenshot of \(Navigation.shared.appName), \(Navigation.shared.windowName)")
-				}
-			} else {
-				Accessibility.speakWithSynthesizer("Faild to access \(Navigation.shared.appName), \(Navigation.shared.windowName)")
-			}
+			initOCR()
 		}
 
 		targetWindow.keyDownHandler = {
@@ -41,15 +33,7 @@ struct Shortcuts {
 				return
 			}
 			setWindow(-1)
-			if Navigation.shared.cgSize != CGSize() {
-				if let  cgImage = TakeScreensShots() {
-					Navigation.shared.startOCR(cgImage:cgImage)
-				} else {
-					Accessibility.speakWithSynthesizer("Faild to take a screenshot of \(Navigation.shared.appName), \(Navigation.shared.windowName)")
-				}
-			} else {
-				Accessibility.speakWithSynthesizer("Faild to access \(Navigation.shared.appName), \(Navigation.shared.windowName)")
-			}
+			initOCR()
 		}
 
 		vo.keyDownHandler = {


### PR DESCRIPTION
When the user clicks the mouse, the "OCR" routines will be run. I introduced a 0.5S delay to make sure the refresh is complete before we OCR again.
FOr the time being, the event monitor will only process left and right mouse clicks.